### PR TITLE
Suggestion for issue #106

### DIFF
--- a/R/task_patch_indic_methods.R
+++ b/R/task_patch_indic_methods.R
@@ -228,7 +228,7 @@ plot_distr.patchdistr_sews_single <- function(x,
   plot <- ggplot() + 
     scale_x_continuous(trans = "log10") +
     scale_y_continuous(trans = "log10") + 
-    spatialwarnings:::theme_spwarnings() +
+    theme_spwarnings() +
     labs(x = 'Patch size',
          y = 'Observed frequency (P>=x)',
          color = 'Fitted type')
@@ -261,7 +261,7 @@ plot_distr.patchdistr_sews_single <- function(x,
     xmin_est <- x$plrange$xmin_est
     
     if (all(xmins_for_fit != 1) && xmin_est != 1){
-      cpsd <- spatialwarnings:::cumpsd(x$psd_obs)
+      cpsd <- cumpsd(x$psd_obs)
       intercept <- cpsd[cpsd$patchsize == xmin_est,"y"]
       
       # Ensure that we are still plotting something if xmin_est 


### PR DESCRIPTION
This possibility allows to view the whole observed distribution while accurately shifting the fitted distributions (only for `plot_distr.patchdistr_sews_single`):

<center>
<img src=https://user-images.githubusercontent.com/95242763/156345266-d58901c0-78d3-4d7b-b585-491e9b1a407e.png width=500 />
</center>

This relies on multiplying all fitted values by the observed cumulative frequency at xmin, resulting in a y-axis shift on the log scale (lines 258-280 in R/task_patch_indic_methods.R)

 I felt like this was a quite quick way to get the plots we want, instead of modifying the axes or the observed data points.
