### PR TITLE
Compatability with upcoming ggplot2 version

### DIFF
--- a/tests/testthat/test-display_matrix.R
+++ b/tests/testthat/test-display_matrix.R
@@ -5,7 +5,7 @@
 context("Test that matrices can be displayed")
 
 isgg <- function(o) { 
-  all(class(o) == c("gg", "ggplot"))
+  inherits(o, c("ggplot", "ggplot2::ggplot"))
 }
 
 test_that("display_matrix methods work", { 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is described in https://github.com/tidyverse/ggplot2/issues/6498, where you're welcome to raise discussion.
Luckily, you had the good foresight to use a testing function, so it is just a small change!

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
